### PR TITLE
feat: switch to DSP 2025 + schema validation

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -14,5 +14,8 @@
  */
 dependencies {
     api(project(":boot"))
+    implementation(libs.schema.validator) {
+        exclude("com.fasterxml.jackson.dataformat", "jackson-dataformat-yaml")
+    }
 }
 

--- a/core/src/main/java/org/eclipse/dataspacetck/core/api/message/MessageSerializer.java
+++ b/core/src/main/java/org/eclipse/dataspacetck/core/api/message/MessageSerializer.java
@@ -17,28 +17,49 @@ package org.eclipse.dataspacetck.core.api.message;
 
 import com.apicatalog.jsonld.JsonLdError;
 import com.apicatalog.jsonld.JsonLdOptions;
+import com.apicatalog.jsonld.document.Document;
 import com.apicatalog.jsonld.document.JsonDocument;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jsonp.JSONPModule;
+import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonStructure;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static com.apicatalog.jsonld.JsonLd.compact;
 import static com.apicatalog.jsonld.JsonLd.expand;
+import static com.apicatalog.jsonld.lang.Keywords.CONTEXT;
+import static com.apicatalog.jsonld.lang.Keywords.TYPE;
+import static java.util.Collections.emptyList;
 
 /**
  * Provides a configured {@link ObjectMapper} for serializing and deserializing JSON-LD messages.
  */
 public class MessageSerializer {
-    public static final JsonDocument EMPTY_CONTEXT = JsonDocument.of(JsonStructure.EMPTY_JSON_OBJECT);
 
+
+    public static final JsonDocument COMPACT_CONTEXT = JsonDocument.of(Json.createObjectBuilder()
+            .add(CONTEXT, Json.createArrayBuilder().add("https://w3id.org/dspace/2025/1/context.jsonld"))
+            .build());
     public static final ObjectMapper MAPPER;
+    private static final Map<URI, Document> CONTEXTS;
+    private static final Map<String, MessageValidator> VALIDATORS = new ConcurrentHashMap<>();
+    private static final Pattern JSONLD_PREFIX_REGEX = Pattern.compile("dataspacetck\\.dsp\\.jsonld\\.context\\.(\\w*)");
+    private static final String JSONLD_PREFIX = "dataspacetck.dsp.jsonld.context.";
 
     static {
         MAPPER = new ObjectMapper();
@@ -50,11 +71,27 @@ public class MessageSerializer {
             }
         };
         MAPPER.registerModule(module);
+        CONTEXTS = new HashMap<>();
+        registerDocument(URI.create("https://w3id.org/dspace/2025/1/context.jsonld"), "dsp-2025-1.jsonld");
+        registerDocument(URI.create("https://w3id.org/dspace/2025/1/odrl-profile.jsonld"), "dsp-2025-1-odrl-profile.jsonld");
+        loadCustomContexts();
+    }
+
+    private MessageSerializer() {
+    }
+
+    public static void registerValidator(String type, MessageValidator validator) {
+        VALIDATORS.put(type, validator);
     }
 
     public static String serialize(Object object) {
         try {
-            var compacted = compact(JsonDocument.of(MAPPER.convertValue(object, JsonObject.class)), EMPTY_CONTEXT).get();
+            var options = new JsonLdOptions((uri, documentLoaderOptions) -> CONTEXTS.get(uri));
+            var compacted = compact(JsonDocument.of(MAPPER.convertValue(object, JsonObject.class)), COMPACT_CONTEXT)
+                    .options(options)
+                    .get();
+            validateMessage(compacted);
+
             return MAPPER.writeValueAsString(compacted);
         } catch (JsonProcessingException | JsonLdError e) {
             throw new RuntimeException(e);
@@ -69,29 +106,29 @@ public class MessageSerializer {
         }
     }
 
-    public static Map<String, Object> processJsonLd(InputStream stream, Map<String, Object> context) {
+    public static Map<String, Object> processJsonLd(InputStream stream) {
         try {
-            return processJsonLd(MAPPER.readValue(stream, JsonObject.class), context);
+            return processJsonLd(MAPPER.readValue(stream, JsonObject.class));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static Map<String, Object> processJsonLd(Map<String, Object> message, Map<String, Object> context) {
-        return processJsonLd(MAPPER.convertValue(message, JsonObject.class), context);
+    public static Map<String, Object> processJsonLd(Map<String, Object> message) {
+        return processJsonLd(MAPPER.convertValue(message, JsonObject.class));
     }
 
     @SuppressWarnings("unchecked")
-    private static Map<String, Object> processJsonLd(JsonObject document, Map<String, Object> context) {
+    private static Map<String, Object> processJsonLd(JsonObject document) {
         try {
-            var options = new JsonLdOptions();
-            options.setExpandContext(MAPPER.convertValue(context, JsonObject.class));
-            options.setCompactArrays(true);
+
+            validateMessage(document);
+
+            var options = new JsonLdOptions((uri, documentLoaderOptions) -> CONTEXTS.get(uri));
             var jsonArray = expand(JsonDocument.of(document)).options(options).get();
             if (jsonArray.isEmpty()) {
                 throw new AssertionError("Invalid Json document, expecting a non-empty array");
             }
-            @SuppressWarnings("SequencedCollectionMethodCanBeUsed")
             var expanded = jsonArray.get(0);
             return MAPPER.convertValue(expanded, Map.class);
         } catch (JsonLdError e) {
@@ -99,8 +136,65 @@ public class MessageSerializer {
         }
     }
 
-    private MessageSerializer() {
+    private static void validateMessage(JsonObject document) {
+        var result = Optional.of(document.getString(TYPE))
+                .map(VALIDATORS::get)
+                .map(validator -> validator.validate(MAPPER.convertValue(document, JsonNode.class)))
+                .orElse(emptyList());
+
+        if (!result.isEmpty()) {
+            throw new AssertionError("Invalid message: " + result);
+        }
+    }
+
+    public static void registerDocument(URI uri, String resource) {
+        var stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(resource);
+        if (stream == null) {
+            throw new IllegalArgumentException("Resource not found: " + resource);
+        }
+        registerDocument(uri, stream);
+    }
+
+    public static void registerDocument(URI uri, InputStream stream) {
+        try {
+            CONTEXTS.put(uri, JsonDocument.of(stream));
+        } catch (JsonLdError e) {
+            throw new RuntimeException(e);
+        }
     }
 
 
+    private static void loadCustomContexts() {
+        var ids = System.getProperties()
+                .stringPropertyNames()
+                .stream()
+                .map(MessageSerializer::getContextName)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        for (var id : ids) {
+            var path = System.getProperty(JSONLD_PREFIX + id + ".path");
+            if (path == null) {
+                continue;
+            }
+            var uri = System.getProperty(JSONLD_PREFIX + id + ".uri");
+            if (uri == null) {
+                continue;
+            }
+            try {
+                registerDocument(URI.create(uri), new FileInputStream(path));
+            } catch (FileNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+    }
+
+    private static String getContextName(String key) {
+        var matcher = JSONLD_PREFIX_REGEX.matcher(key);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return null;
+    }
 }

--- a/core/src/main/java/org/eclipse/dataspacetck/core/api/message/MessageValidator.java
+++ b/core/src/main/java/org/eclipse/dataspacetck/core/api/message/MessageValidator.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspacetck.core.api.message;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.List;
+
+/**
+ * Interface for validating messages.
+ * <p>
+ * Implementations should provide validation logic for specific message types.
+ */
+public interface MessageValidator {
+    List<String> validate(JsonNode message);
+}

--- a/core/src/main/java/org/eclipse/dataspacetck/core/api/pipeline/AbstractAsyncPipeline.java
+++ b/core/src/main/java/org/eclipse/dataspacetck/core/api/pipeline/AbstractAsyncPipeline.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
@@ -41,7 +40,6 @@ public abstract class AbstractAsyncPipeline<P extends AsyncPipeline<P>> implemen
     protected CallbackEndpoint endpoint;
     protected Monitor monitor;
     protected long waitTime;
-    protected Supplier<Map<String, Object>> context;
 
     protected List<Runnable> stages = new ArrayList<>();
 
@@ -65,11 +63,10 @@ public abstract class AbstractAsyncPipeline<P extends AsyncPipeline<P>> implemen
      */
     protected Deque<CountDownLatch> expectLatches = new ArrayDeque<>();
 
-    public AbstractAsyncPipeline(CallbackEndpoint endpoint, Monitor monitor, long waitTime, Supplier<Map<String, Object>> context) {
+    public AbstractAsyncPipeline(CallbackEndpoint endpoint, Monitor monitor, long waitTime) {
         this.endpoint = endpoint;
         this.waitTime = waitTime;
         this.monitor = monitor;
-        this.context = context;
     }
 
     public P thenWait(String description, Callable<Boolean> condition) {
@@ -111,7 +108,7 @@ public abstract class AbstractAsyncPipeline<P extends AsyncPipeline<P>> implemen
         expectLatches.add(latch);
         stages.add(() ->
                 endpoint.registerHandler(path, agreement -> {
-                    action.accept((MessageSerializer.processJsonLd(agreement, context.get())));
+                    action.accept((MessageSerializer.processJsonLd(agreement)));
                     endpoint.deregisterHandler(path);
                     latch.countDown();
                     return null;

--- a/core/src/main/java/org/eclipse/dataspacetck/core/api/verification/AbstractVerificationTest.java
+++ b/core/src/main/java/org/eclipse/dataspacetck/core/api/verification/AbstractVerificationTest.java
@@ -15,12 +15,43 @@
 
 package org.eclipse.dataspacetck.core.api.verification;
 
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SchemaLocation;
+import com.networknt.schema.ValidationMessage;
+import org.eclipse.dataspacetck.core.api.message.MessageValidator;
 import org.eclipse.dataspacetck.core.system.SystemBootstrapExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.networknt.schema.SpecVersion.VersionFlag.V202012;
+
 
 /**
  * Base class for verification tests. Uses the system bootstrap extension.
  */
 @ExtendWith(SystemBootstrapExtension.class)
 public abstract class AbstractVerificationTest {
+
+    protected static final String CLASSPATH_SCHEMA = "classpath:/";
+    protected static final String DSPACE_NAMESPACE = "https://w3id.org/dspace/2025/1";
+
+    private static final JsonSchemaFactory SCHEMA_FACTORY = JsonSchemaFactory.getInstance(V202012, builder ->
+            builder.schemaMappers(schemaMappers ->
+                    schemaMappers.mapPrefix(DSPACE_NAMESPACE + "/", CLASSPATH_SCHEMA))
+    );
+
+
+    protected static MessageValidator forSchema(String schema) {
+        return (input) -> {
+            var schemaValidator = SCHEMA_FACTORY.getSchema(SchemaLocation.of(DSPACE_NAMESPACE + schema));
+
+            var response = schemaValidator.validate(input);
+            if (response.isEmpty()) {
+                return List.of();
+            }
+            return response.stream().map(ValidationMessage::getMessage).collect(Collectors.toList());
+        };
+    }
 }

--- a/core/src/main/java/org/eclipse/dataspacetck/core/system/SystemBootstrapExtension.java
+++ b/core/src/main/java/org/eclipse/dataspacetck/core/system/SystemBootstrapExtension.java
@@ -60,13 +60,12 @@ public class SystemBootstrapExtension implements BeforeAllCallback,
     private static final ExtensionContext.Namespace CALLBACK_NAMESPACE = org.junit.jupiter.api.extension.ExtensionContext.Namespace.create(new Object());
 
     private static boolean started;
-
-    private String callbackHost;
-    private int callbackPort;
     private static SystemLauncher launcher;
     private static DispatchingHandler dispatchingHandler;
     private static HttpServer server;
     private static ConsoleMonitor monitor;
+    private String callbackHost;
+    private int callbackPort;
     private ExecutorService executorService;
 
     @Override
@@ -243,6 +242,7 @@ public class SystemBootstrapExtension implements BeforeAllCallback,
                     var response = endpoint.apply(path, exchange.getRequestHeaders(), exchange.getRequestBody());
                     if (response.result() == null) {
                         exchange.sendResponseHeaders(response.code(), 0);
+                        exchange.close();
                     } else {
                         var bytes = response.result().getBytes();
                         exchange.sendResponseHeaders(response.code(), bytes.length);
@@ -254,6 +254,7 @@ public class SystemBootstrapExtension implements BeforeAllCallback,
                 }
             }
             exchange.sendResponseHeaders(404, 0);
+            exchange.close();
         }
     }
 

--- a/core/src/main/resources/dsp-2025-1-odrl-profile.jsonld
+++ b/core/src/main/resources/dsp-2025-1-odrl-profile.jsonld
@@ -1,0 +1,95 @@
+{
+  "@context": {
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "Policy": "odrl:Policy",
+    "Rule": "odrl:Rule",
+    "profile": {
+      "@type": "@id",
+      "@id": "odrl:profile"
+    },
+    "prohibit": "odrl:prohibit",
+    "Agreement": "odrl:Agreement",
+    "Assertion": "odrl:Assertion",
+    "Offer": "odrl:Offer",
+    "Set": "odrl:Set",
+    "Asset": "odrl:Asset",
+    "hasPolicy": {
+      "@type": "@id",
+      "@id": "odrl:hasPolicy"
+    },
+    "target": {
+      "@type": "@id",
+      "@id": "odrl:target"
+    },
+    "assignee": {
+      "@type": "@id",
+      "@id": "odrl:assignee"
+    },
+    "assigner": {
+      "@type": "@id",
+      "@id": "odrl:assigner"
+    },
+    "Action": "odrl:Action",
+    "action": {
+      "@type": "@vocab",
+      "@id": "odrl:action"
+    },
+    "Permission": "odrl:Permission",
+    "permission": {
+      "@type": "@id",
+      "@id": "odrl:permission",
+      "@container": "@set"
+    },
+    "Prohibition": "odrl:Prohibition",
+    "prohibition": {
+      "@type": "@id",
+      "@id": "odrl:prohibition",
+      "@container": "@set"
+    },
+    "obligation": {
+      "@type": "@id",
+      "@id": "odrl:obligation",
+      "@container": "@set"
+    },
+    "use": "odrl:use",
+    "Duty": "odrl:Duty",
+    "duty": {
+      "@type": "@id",
+      "@id": "odrl:duty"
+    },
+    "Constraint": "odrl:Constraint",
+    "constraint": {
+      "@type": "@id",
+      "@id": "odrl:constraint",
+      "@container": "@set"
+    },
+    "Operator": "odrl:Operator",
+    "operator": {
+      "@type": "@vocab",
+      "@id": "odrl:operator"
+    },
+    "RightOperand": "odrl:RightOperand",
+    "rightOperand": "odrl:rightOperand",
+    "LeftOperand": "odrl:LeftOperand",
+    "leftOperand": {
+      "@type": "@vocab",
+      "@id": "odrl:leftOperand"
+    },
+    "eq": "odrl:eq",
+    "gt": "odrl:gt",
+    "gteq": "odrl:gteq",
+    "lt": "odrl:lt",
+    "lteq": "odrl:lteq",
+    "neq": "odrl:neq",
+    "isA": "odrl:isA",
+    "hasPart": "odrl:hasPart",
+    "isPartOf": "odrl:isPartOf",
+    "isAllOf": "odrl:isAllOf",
+    "isAnyOf": "odrl:isAnyOf",
+    "isNoneOf": "odrl:isNoneOf",
+    "or": "odrl:or",
+    "xone": "odrl:xone",
+    "and": "odrl:and",
+    "andSequence": "odrl:andSequence"
+  }
+}

--- a/core/src/main/resources/dsp-2025-1.jsonld
+++ b/core/src/main/resources/dsp-2025-1.jsonld
@@ -1,0 +1,452 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "dct": "http://purl.org/dc/terms/",
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "dspace": "https://w3id.org/dspace/2025/1/",
+    "DatasetRequestMessage": {
+      "@id": "dspace:DatasetRequestMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "dataset": "dspace:dataset"
+      }
+    },
+    "CatalogRequestMessage": {
+      "@id": "dspace:CatalogRequestMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "filter": {
+          "@id": "dspace:filter",
+          "@container": "@set"
+        }
+      }
+    },
+    "CatalogError": {
+      "@id": "dspace:CatalogError",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        }
+      }
+    },
+    "ContractRequestMessage": {
+      "@id": "dspace:ContractRequestMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "@import": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+        "@propagate": true,
+        "callbackAddress": "dspace:callbackAddress",
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "offer": {
+          "@type": "@id",
+          "@id": "dspace:offer"
+        }
+      }
+    },
+    "ContractOfferMessage": {
+      "@id": "dspace:ContractOfferMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "@import": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+        "@propagate": true,
+        "callbackAddress": "dspace:callbackAddress",
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "offer": {
+          "@type": "@id",
+          "@id": "dspace:offer"
+        }
+      }
+    },
+    "ContractAgreementMessage": {
+      "@id": "dspace:ContractAgreementMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "@import": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+        "@propagate": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "agreement": {
+          "@id": "dspace:agreement",
+          "@type": "@id"
+        },
+        "callbackAddress": "dspace:callbackAddress",
+        "timestamp": "dspace:timestamp"
+      }
+    },
+    "ContractAgreementVerificationMessage": {
+      "@id": "dspace:ContractAgreementVerificationMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        }
+      }
+    },
+    "ContractNegotiationEventMessage": {
+      "@id": "dspace:ContractNegotiationEventMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "eventType": {
+          "@type": "@vocab",
+          "@id": "dspace:eventType"
+        }
+      }
+    },
+    "ContractNegotiationTerminationMessage": {
+      "@id": "dspace:ContractNegotiationTerminationMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        },
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        }
+      }
+    },
+    "ContractNegotiation": {
+      "@id": "dspace:ContractNegotiation",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "state": {
+          "@type": "@vocab",
+          "@id": "dspace:state"
+        }
+      }
+    },
+    "ContractNegotiationError": {
+      "@id": "dspace:ContractNegotiationError",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        }
+      }
+    },
+    "TransferRequestMessage": {
+      "@id": "dspace:TransferRequestMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "callbackAddress": "dspace:callbackAddress",
+        "dataAddress": "dspace:dataAddress",
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "format": {
+          "@type": "@vocab",
+          "@id": "dct:format"
+        },
+        "agreementId": {
+          "@type": "@id",
+          "@id": "dspace:agreementId"
+        }
+      }
+    },
+    "TransferStartMessage": {
+      "@id": "dspace:TransferStartMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "dataAddress": "dspace:dataAddress"
+      }
+    },
+    "TransferCompletionMessage": {
+      "@id": "dspace:TransferCompletionMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        }
+      }
+    },
+    "TransferTerminationMessage": {
+      "@id": "dspace:TransferTerminationMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        },
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        }
+      }
+    },
+    "TransferSuspensionMessage": {
+      "@id": "dspace:TransferSuspensionMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        },
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        }
+      }
+    },
+    "TransferError": {
+      "@id": "dspace:TransferError",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "consumerPid": "dspace:consumerPid",
+        "providerPid": "dspace:providerPid",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        }
+      }
+    },
+    "DataAddress": {
+      "@id": "dspace:DataAddress",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "endpointType": {
+          "@type": "@vocab",
+          "@id": "dspace:endpointType"
+        },
+        "endpointProperties": {
+          "@id": "dspace:endpointProperties",
+          "@container": "@set"
+        },
+        "endpoint": "dspace:endpoint"
+      }
+    },
+    "EndpointProperty": {
+      "@id": "dspace:EndpointProperty",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "name": "dspace:name",
+        "value": "dspace:value"
+      }
+    },
+    "TransferProcess": {
+      "@id": "dspace:TransferProcess",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "state": {
+          "@type": "@vocab",
+          "@id": "dspace:state"
+        }
+      }
+    },
+    "VersionsError": {
+      "@id": "dspace:VersionsError",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        }
+      }
+    },
+    "Catalog": {
+      "@id": "dcat:Catalog",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "service": {
+          "@id": "dcat:service",
+          "@container": "@set"
+        },
+        "participantId": {
+          "@type": "@id",
+          "@id": "dspace:participantId"
+        },
+        "catalog": {
+          "@id": "dcat:catalog",
+          "@container": "@set"
+        },
+        "dataset": {
+          "@id": "dcat:dataset",
+          "@container": "@set"
+        },
+        "distribution": {
+          "@id": "dcat:distribution",
+          "@container": "@set"
+        }
+      }
+    },
+    "Dataset": {
+      "@id": "dcat:Dataset",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "@import": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+        "@propagate": true,
+        "distribution": {
+          "@id": "dcat:distribution",
+          "@container": "@set"
+        },
+        "hasPolicy": {
+          "@id": "odrl:hasPolicy",
+          "@container": "@set"
+        }
+      }
+    },
+    "DataService": {
+      "@id": "dcat:DataService",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "endpointDescription": "dcat:endpointDescription",
+        "endpointURL": "dcat:endpointURL"
+      }
+    },
+    "Distribution": {
+      "@id": "dcat:Distribution",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "format": {
+          "@type": "@vocab",
+          "@id": "dct:format"
+        },
+        "accessService": {
+          "@id": "dcat:accessService"
+        }
+      }
+    },
+    "CatalogService": {
+      "@id": "dspace:CatalogService",
+      "@context": {
+        "id": "@id",
+        "type": "@type",
+        "serviceEndpoint": {
+          "@id": "https://www.w3.org/ns/did#serviceEndpoint",
+          "@type": "@id"
+        }
+      }
+    },
+    "ACCEPTED": "dspace:ACCEPTED",
+    "FINALIZED": "dspace:FINALIZED",
+    "REQUESTED": "dspace:REQUESTED",
+    "STARTED": "dspace:STARTED",
+    "COMPLETED": "dspace:COMPLETED",
+    "SUSPENDED": "dspace:SUSPENDED",
+    "TERMINATED": "dspace:TERMINATED",
+    "OFFERED": "dspace:OFFERED",
+    "AGREED": "dspace:AGREED",
+    "VERIFIED": "dspace:VERIFIED"
+  }
+}

--- a/dsp/dsp-api/src/main/java/org/eclipse/dataspacetck/dsp/system/api/http/HttpFunctions.java
+++ b/dsp/dsp-api/src/main/java/org/eclipse/dataspacetck/dsp/system/api/http/HttpFunctions.java
@@ -33,11 +33,14 @@ import static org.eclipse.dataspacetck.core.api.message.MessageSerializer.serial
 public class HttpFunctions {
     private static Interceptor authorizationInterceptor = chain -> chain.proceed(chain.request());
 
+    private HttpFunctions() {
+    }
+
     public static void registerAuthorizationInterceptor(String authorizationHeader) {
         authorizationInterceptor = chain -> {
             var request = chain.request();
             var authenticatedRequest = request.newBuilder()
-                            .header("Authorization", authorizationHeader).build();
+                    .header("Authorization", authorizationHeader).build();
             return chain.proceed(authenticatedRequest);
         };
     }
@@ -67,6 +70,8 @@ public class HttpFunctions {
                 if (response.code() < 400 || response.code() >= 500 || !expectError) {
                     throw new AssertionError("Unexpected response code: " + response.code());
                 }
+            } else if (expectError) {
+                throw new AssertionError("Expected to throw an error on request: " + url);
             }
             return response;
         } catch (IOException e) {
@@ -92,8 +97,5 @@ public class HttpFunctions {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private HttpFunctions() {
     }
 }

--- a/dsp/dsp-api/src/main/java/org/eclipse/dataspacetck/dsp/system/api/message/DspConstants.java
+++ b/dsp/dsp-api/src/main/java/org/eclipse/dataspacetck/dsp/system/api/message/DspConstants.java
@@ -22,7 +22,9 @@ public interface DspConstants {
 
     String TCK_PARTICIPANT_ID = "TCK_PARTICIPANT";
 
-    String DSPACE_NAMESPACE = "https://w3id.org/dspace/v0.8/";
+    String DSPACE_NAMESPACE = "https://w3id.org/dspace/2025/1/";
+
+    String DSPACE_CONTEXT = "https://w3id.org/dspace/2025/1/context.jsonld";
 
     String CONTEXT = "@context";
 
@@ -32,38 +34,22 @@ public interface DspConstants {
 
     String TYPE = "@type";
 
-    String DSPACE_NAMESPACE_KEY = "dspace";
 
-    String DSPACE_NAMESPACE_PREFIX = DSPACE_NAMESPACE_KEY + ":";
-
-    String DSPACE_PROPERTY_TIMESTAMP = DSPACE_NAMESPACE_PREFIX + "timestamp";
-
-    String DSPACE_PROPERTY_CONSUMER_PID = DSPACE_NAMESPACE_PREFIX + "consumerPid";
-
+    String DSPACE_PROPERTY_TIMESTAMP = "timestamp";
+    String DSPACE_PROPERTY_PROVIDER_PID = "providerPid";
+    String DSPACE_PROPERTY_CODE = "code";
+    String DSPACE_PROPERTY_REASON = "reason";
+    String DSPACE_PROPERTY_STATE = "state";
+    String DSPACE_PROPERTY_EVENT_TYPE = "eventType";
+    String DSPACE_PROPERTY_CALLBACK_ADDRESS = "callbackAddress";
+    String DSPACE_PROPERTY_OFFER = "offer";
+    String DSPACE_PROPERTY_CONSUMER_PID = "consumerPid";
+    String DSPACE_PROPERTY_AGREEMENT = "agreement";
     String DSPACE_PROPERTY_CONSUMER_PID_EXPANDED = DSPACE_NAMESPACE + "consumerPid";
-
-    String DSPACE_PROPERTY_PROVIDER_PID = DSPACE_NAMESPACE_PREFIX + "providerPid";
-
     String DSPACE_PROPERTY_PROVIDER_PID_EXPANDED = DSPACE_NAMESPACE + "providerPid";
-
-    String DSPACE_PROPERTY_CODE = DSPACE_NAMESPACE_PREFIX + "code";
-
-    String DSPACE_PROPERTY_REASON = DSPACE_NAMESPACE_PREFIX + "reason";
-
-    String DSPACE_PROPERTY_STATE = DSPACE_NAMESPACE_PREFIX + "state";
-
     String DSPACE_PROPERTY_STATE_EXPANDED = DSPACE_NAMESPACE + "state";
-
-    String DSPACE_PROPERTY_EVENT_TYPE = DSPACE_NAMESPACE_PREFIX + "eventType";
-
     String DSPACE_PROPERTY_EVENT_TYPE_EXPANDED = DSPACE_NAMESPACE + "eventType";
-
-    String DSPACE_PROPERTY_CALLBACK_ADDRESS = DSPACE_NAMESPACE_PREFIX + "callbackAddress";
-
     String DSPACE_PROPERTY_CALLBACK_ADDRESS_EXPANDED = DSPACE_NAMESPACE + "callbackAddress";
-
-    String DSPACE_PROPERTY_OFFER = DSPACE_NAMESPACE_PREFIX + "offer";
-
     String DSPACE_PROPERTY_OFFER_EXPANDED = DSPACE_NAMESPACE + "offer";
 
 }

--- a/dsp/dsp-api/src/main/java/org/eclipse/dataspacetck/dsp/system/api/message/MessageFunctions.java
+++ b/dsp/dsp-api/src/main/java/org/eclipse/dataspacetck/dsp/system/api/message/MessageFunctions.java
@@ -31,9 +31,8 @@ import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.eclipse.dataspacetck.dsp.system.api.message.DspConstants.CONTEXT;
-import static org.eclipse.dataspacetck.dsp.system.api.message.DspConstants.DSPACE_NAMESPACE;
-import static org.eclipse.dataspacetck.dsp.system.api.message.DspConstants.DSPACE_NAMESPACE_KEY;
-import static org.eclipse.dataspacetck.dsp.system.api.message.DspConstants.DSPACE_NAMESPACE_PREFIX;
+import static org.eclipse.dataspacetck.dsp.system.api.message.DspConstants.DSPACE_CONTEXT;
+import static org.eclipse.dataspacetck.dsp.system.api.message.DspConstants.DSPACE_PROPERTY_AGREEMENT;
 import static org.eclipse.dataspacetck.dsp.system.api.message.DspConstants.DSPACE_PROPERTY_CALLBACK_ADDRESS;
 import static org.eclipse.dataspacetck.dsp.system.api.message.DspConstants.DSPACE_PROPERTY_CODE;
 import static org.eclipse.dataspacetck.dsp.system.api.message.DspConstants.DSPACE_PROPERTY_CONSUMER_PID;
@@ -47,8 +46,6 @@ import static org.eclipse.dataspacetck.dsp.system.api.message.DspConstants.ID;
 import static org.eclipse.dataspacetck.dsp.system.api.message.DspConstants.TYPE;
 import static org.eclipse.dataspacetck.dsp.system.api.message.DspConstants.VALUE;
 import static org.eclipse.dataspacetck.dsp.system.api.message.OdrlConstants.ODRL_AGREEMENT_TYPE;
-import static org.eclipse.dataspacetck.dsp.system.api.message.OdrlConstants.ODRL_NAMESPACE;
-import static org.eclipse.dataspacetck.dsp.system.api.message.OdrlConstants.ODRL_NAMESPACE_KEY;
 import static org.eclipse.dataspacetck.dsp.system.api.message.OdrlConstants.ODRL_OFFER_TYPE;
 import static org.eclipse.dataspacetck.dsp.system.api.message.OdrlConstants.ODRL_PROPERTY_ACTION;
 import static org.eclipse.dataspacetck.dsp.system.api.message.OdrlConstants.ODRL_PROPERTY_ASSIGNEE;
@@ -65,8 +62,11 @@ public class MessageFunctions {
     private static final Map<String, String> IDENTITY_TYPE = Map.of("@type", "@id");
 
 
+    private MessageFunctions() {
+    }
+
     public static Map<String, Object> createTermination(String providerId, String consumerId, String code, String... reasons) {
-        var message = createBaseMessage(DSPACE_NAMESPACE_PREFIX + "ContractNegotiationTerminationMessage");
+        var message = createBaseMessage("ContractNegotiationTerminationMessage");
         message.put(CONTEXT, createDspContext());
 
         message.put(DSPACE_PROPERTY_PROVIDER_PID, providerId);
@@ -88,17 +88,17 @@ public class MessageFunctions {
     }
 
     public static Map<String, Object> createEvent(String providerId, String consumerId, String eventType) {
-        var message = createBaseMessage(DSPACE_NAMESPACE_PREFIX + "ContractNegotiationEventMessage");
+        var message = createBaseMessage("ContractNegotiationEventMessage");
         message.put(CONTEXT, createDspContext());
         message.put(DSPACE_PROPERTY_PROVIDER_PID, providerId);
         message.put(DSPACE_PROPERTY_CONSUMER_PID, consumerId);
 
-        message.put(DSPACE_PROPERTY_EVENT_TYPE, DSPACE_NAMESPACE + eventType);
+        message.put(DSPACE_PROPERTY_EVENT_TYPE, eventType);
         return message;
     }
 
     public static Map<String, Object> createContractRequest(String consumerPid, String offerId, String targetId, String callbackAddress) {
-        var message = createBaseMessage(DSPACE_NAMESPACE_PREFIX + "ContractRequestMessage");
+        var message = createBaseMessage("ContractRequestMessage");
         message.put(CONTEXT, createDspContext());
         message.put(DSPACE_PROPERTY_CONSUMER_PID, consumerPid);
 
@@ -106,7 +106,9 @@ public class MessageFunctions {
         var offer = new LinkedHashMap<String, Object>();
         offer.put(ID, offerId);
         offer.put(ODRL_PROPERTY_TARGET, targetId);
-        offer.put(TYPE, ODRL_NAMESPACE + "Offer");    // WORKAROUND: REMOVE - @type
+        offer.put(TYPE, ODRL_OFFER_TYPE);    // WORKAROUND: REMOVE - @type
+        var permissions = Map.of(ODRL_PROPERTY_ACTION, ODRL_USE, ODRL_PROPERTY_CONSTRAINTS, emptyList());
+        offer.put(ODRL_PROPERTY_PERMISSION, List.of(permissions));
 
         message.put(DSPACE_PROPERTY_OFFER, offer);
 
@@ -122,7 +124,7 @@ public class MessageFunctions {
                                                          String assignee,
                                                          String targetId,
                                                          String callbackAddress) {
-        var message = createBaseMessage(DSPACE_NAMESPACE_PREFIX + "ContractRequestMessage"); // do NOT override id
+        var message = createBaseMessage("ContractRequestMessage"); // do NOT override id
         message.put(CONTEXT, createDspContext());
         message.put(DSPACE_PROPERTY_PROVIDER_PID, providerId);
         message.put(DSPACE_PROPERTY_CONSUMER_PID, consumerId);
@@ -134,7 +136,7 @@ public class MessageFunctions {
     }
 
     public static Map<String, Object> createVerification(String providerId, String consumerId) {
-        var message = createBaseMessage(DSPACE_NAMESPACE_PREFIX + "ContractAgreementVerificationMessage");
+        var message = createBaseMessage("ContractAgreementVerificationMessage");
         message.put(CONTEXT, createDspContext());
 
         message.put(DSPACE_PROPERTY_PROVIDER_PID, providerId);
@@ -149,7 +151,7 @@ public class MessageFunctions {
                                                   String assignee,
                                                   String targetId,
                                                   String callbackAddress) {
-        var message = createBaseMessage(DSPACE_NAMESPACE_PREFIX + "ContractOfferMessage");
+        var message = createBaseMessage("ContractOfferMessage");
         var context = createDspContext();
         message.put(CONTEXT, context);
         message.put(DSPACE_PROPERTY_PROVIDER_PID, providerId);
@@ -186,8 +188,9 @@ public class MessageFunctions {
                                                       String agreementId,
                                                       String assigner,
                                                       String assignee,
-                                                      String targetId) {
-        var message = createBaseMessage(DSPACE_NAMESPACE_PREFIX + "ContractAgreementMessage");
+                                                      String targetId,
+                                                      String callbackAddress) {
+        var message = createBaseMessage("ContractAgreementMessage");
         var context = createDspContext();
         message.put(CONTEXT, context);
         message.put(DSPACE_PROPERTY_PROVIDER_PID, providerId);
@@ -203,13 +206,14 @@ public class MessageFunctions {
         offer.put(ODRL_PROPERTY_ASSIGNEE, assignee);
         offer.put(ODRL_PROPERTY_ASSIGNER, assigner);
 
-        message.put(DSPACE_NAMESPACE_PREFIX + "agreement", offer);
+        message.put(DSPACE_PROPERTY_AGREEMENT, offer);
+        message.put(DSPACE_PROPERTY_CALLBACK_ADDRESS, callbackAddress);
 
         return message;
     }
 
     public static Map<String, Object> createNegotiationResponse(String providerPid, String consumerPid, String state) {
-        var message = createBaseMessage(DSPACE_NAMESPACE_PREFIX + "ContractNegotiation");
+        var message = createBaseMessage("ContractNegotiation");
         var context = createDspContext();
         message.put(CONTEXT, context);
         message.put(DSPACE_PROPERTY_PROVIDER_PID, providerPid);
@@ -277,16 +281,8 @@ public class MessageFunctions {
         throw new AssertionError(format("Property '%s' was not in expanded @id form", key));
     }
 
-    public static Map<String, Object> createDspContext() {
-        var context = new LinkedHashMap<String, Object>();
-        context.put(DSPACE_NAMESPACE_KEY, DSPACE_NAMESPACE);
-        context.put(ODRL_NAMESPACE_KEY, ODRL_NAMESPACE);
-        context.put("target", "odrl:target");
-        context.put("odrl:target", IDENTITY_TYPE);
-        context.put(DSPACE_NAMESPACE_PREFIX + "state", IDENTITY_TYPE);
-        context.put(DSPACE_NAMESPACE_PREFIX + "consumerPid", IDENTITY_TYPE);
-        context.put(DSPACE_NAMESPACE_PREFIX + "providerPid", IDENTITY_TYPE);
-        return context;
+    public static List<String> createDspContext() {
+        return List.of(DSPACE_CONTEXT);
     }
 
     @NotNull
@@ -295,9 +291,6 @@ public class MessageFunctions {
         message.put(ID, UUID.randomUUID().toString());
         message.put(TYPE, type);
         return message;
-    }
-
-    private MessageFunctions() {
     }
 
 }

--- a/dsp/dsp-api/src/main/java/org/eclipse/dataspacetck/dsp/system/api/message/OdrlConstants.java
+++ b/dsp/dsp-api/src/main/java/org/eclipse/dataspacetck/dsp/system/api/message/OdrlConstants.java
@@ -20,29 +20,18 @@ package org.eclipse.dataspacetck.dsp.system.api.message;
  */
 public interface OdrlConstants {
 
-    String ODRL_NAMESPACE = "http://www.w3.org/ns/odrl/2/";
 
-    String ODRL_NAMESPACE_KEY = "odrl";
+    String ODRL_AGREEMENT_TYPE = "Agreement";
+    String ODRL_OFFER_TYPE = "Offer";
 
-    String ODRL_NAMESPACE_PREFIX = ODRL_NAMESPACE_KEY + ":";
+    String ODRL_PROPERTY_ACTION = "action";
+    String ODRL_USE = "use";
 
-    String ODRL_AGREEMENT_TYPE = ODRL_NAMESPACE_PREFIX + "Agreement";
-
-    String ODRL_OFFER_TYPE = ODRL_NAMESPACE_PREFIX + "Offer";
-
-    String ODRL_PROPERTY_ACTION = ODRL_NAMESPACE_PREFIX + "action";
-
-    String ODRL_USE = ODRL_NAMESPACE_PREFIX + "use";
-
-    String ODRL_PROPERTY_CONSTRAINTS = ODRL_NAMESPACE_PREFIX + "constraints";
-
-    String ODRL_PROPERTY_PERMISSION = ODRL_NAMESPACE_PREFIX + "permission";
-
-    String ODRL_PROPERTY_TARGET = ODRL_NAMESPACE_PREFIX + "target";
-
-    String ODRL_PROPERTY_ASSIGNEE = ODRL_NAMESPACE_PREFIX + "assignee";
-
-    String ODRL_PROPERTY_ASSIGNER = ODRL_NAMESPACE_PREFIX + "assigner";
+    String ODRL_PROPERTY_CONSTRAINTS = "constraints";
+    String ODRL_PROPERTY_PERMISSION = "permission";
+    String ODRL_PROPERTY_ASSIGNEE = "assignee";
+    String ODRL_PROPERTY_ASSIGNER = "assigner";
+    String ODRL_PROPERTY_TARGET = "target";
 
 
 }

--- a/dsp/dsp-contract-negotiation/build.gradle.kts
+++ b/dsp/dsp-contract-negotiation/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.eclipse.dataspacetck.gradle.plugins.tckgen.TckGeneratorExtension
-
 /*
  *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *

--- a/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/AbstractContractNegotiationConsumerTest.java
+++ b/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/AbstractContractNegotiationConsumerTest.java
@@ -16,7 +16,6 @@
 package org.eclipse.dataspacetck.dsp.verification.cn;
 
 import org.eclipse.dataspacetck.core.api.system.Inject;
-import org.eclipse.dataspacetck.core.api.verification.AbstractVerificationTest;
 import org.eclipse.dataspacetck.dsp.system.api.connector.Connector;
 import org.eclipse.dataspacetck.dsp.system.api.connector.Provider;
 import org.eclipse.dataspacetck.dsp.system.api.mock.ConsumerNegotiationMock;
@@ -27,7 +26,7 @@ import org.junit.jupiter.api.Tag;
  * Base class for verifying a connector in the consumer role.
  */
 @Tag("dsp-cn")
-public abstract class AbstractContractNegotiationConsumerTest extends AbstractVerificationTest {
+public abstract class AbstractContractNegotiationConsumerTest extends AbstractContractNegotiationTest {
 
     @Inject
     @Provider

--- a/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/AbstractContractNegotiationProviderTest.java
+++ b/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/AbstractContractNegotiationProviderTest.java
@@ -17,7 +17,6 @@ package org.eclipse.dataspacetck.dsp.verification.cn;
 
 import org.eclipse.dataspacetck.core.api.system.ConfigParam;
 import org.eclipse.dataspacetck.core.api.system.Inject;
-import org.eclipse.dataspacetck.core.api.verification.AbstractVerificationTest;
 import org.eclipse.dataspacetck.dsp.system.api.connector.Connector;
 import org.eclipse.dataspacetck.dsp.system.api.connector.Consumer;
 import org.eclipse.dataspacetck.dsp.system.api.mock.ProviderNegotiationMock;
@@ -31,7 +30,7 @@ import static org.eclipse.dataspacetck.dsp.system.api.connector.IdGenerator.OFFE
  * Base class for verifying a connector in the provider role.
  */
 @Tag("dsp-cn")
-public abstract class AbstractContractNegotiationProviderTest extends AbstractVerificationTest {
+public abstract class AbstractContractNegotiationProviderTest extends AbstractContractNegotiationTest {
 
     @Inject
     @Consumer

--- a/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/AbstractContractNegotiationTest.java
+++ b/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/AbstractContractNegotiationTest.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspacetck.dsp.verification.cn;
+
+import org.eclipse.dataspacetck.core.api.verification.AbstractVerificationTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import static org.eclipse.dataspacetck.core.api.message.MessageSerializer.registerValidator;
+
+public class AbstractContractNegotiationTest extends AbstractVerificationTest {
+
+
+    @BeforeAll
+    static void setUp() {
+        registerValidator("ContractRequestMessage", forSchema("/negotiation/contract-request-message-schema.json"));
+        registerValidator("ContractOfferMessage", forSchema("/negotiation/contract-offer-message-schema.json"));
+        registerValidator("ContractAgreementMessage", forSchema("/negotiation/contract-agreement-message-schema.json"));
+        registerValidator("ContractAgreementVerificationMessage", forSchema("/negotiation/contract-agreement-verification-message-schema.json"));
+        registerValidator("ContractNegotiationEventMessage", forSchema("/negotiation/contract-negotiation-event-message-schema.json"));
+        registerValidator("ContractNegotiationTerminationMessage", forSchema("/negotiation/contract-negotiation-termination-message-schema.json"));
+        registerValidator("ContractNegotiation", forSchema("/negotiation/contract-negotiation-schema.json"));
+        registerValidator("ContractNegotiationError", forSchema("/negotiation/contract-negotiation-error-schema.json"));
+    }
+}

--- a/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ConsumerActions.java
+++ b/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ConsumerActions.java
@@ -23,7 +23,6 @@ import static org.eclipse.dataspacetck.dsp.system.api.http.HttpFunctions.postJso
 import static org.eclipse.dataspacetck.dsp.system.api.message.DspConstants.DSPACE_PROPERTY_PROVIDER_PID_EXPANDED;
 import static org.eclipse.dataspacetck.dsp.system.api.message.MessageFunctions.createAcceptedEvent;
 import static org.eclipse.dataspacetck.dsp.system.api.message.MessageFunctions.createContractRequest;
-import static org.eclipse.dataspacetck.dsp.system.api.message.MessageFunctions.createDspContext;
 import static org.eclipse.dataspacetck.dsp.system.api.message.MessageFunctions.createVerification;
 import static org.eclipse.dataspacetck.dsp.system.api.message.MessageFunctions.stringIdProperty;
 import static org.eclipse.dataspacetck.dsp.system.api.statemachine.ContractNegotiation.State.ACCEPTED;
@@ -38,6 +37,9 @@ public class ConsumerActions {
     private static final String REQUEST_PATH = "%s/negotiations/request";
     private static final String VERIFICATION_PATH = "%s/negotiations/%s/agreement/verification";
 
+    private ConsumerActions() {
+    }
+
     public static void postRequest(String baseUrl, ContractNegotiation negotiation) {
         var url = format(REQUEST_PATH, baseUrl);
         var contractRequest = createContractRequest(negotiation.getId(), negotiation.getOfferId(), negotiation.getDatasetId(), baseUrl);
@@ -45,8 +47,8 @@ public class ConsumerActions {
             // get the response and update the negotiation with the provider process id
             checkResponse(response);
             assert response.body() != null;
-            var jsonResponse = processJsonLd(response.body().byteStream(), createDspContext());
-            var providerId = stringIdProperty(DSPACE_PROPERTY_PROVIDER_PID_EXPANDED, jsonResponse); // FIXME https://github.com/eclipse-dataspacetck/cvf/issues/92
+            var jsonResponse = processJsonLd(response.body().byteStream());
+            var providerId = stringIdProperty(DSPACE_PROPERTY_PROVIDER_PID_EXPANDED, jsonResponse);
             negotiation.setCorrelationId(providerId, REQUESTED);
         }
     }
@@ -73,9 +75,6 @@ public class ConsumerActions {
         if (!response.isSuccessful()) {
             throw new AssertionError("Unexpected response code: " + response.code());
         }
-    }
-
-    private ConsumerActions() {
     }
 
 }

--- a/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ProviderActions.java
+++ b/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ProviderActions.java
@@ -39,6 +39,9 @@ public class ProviderActions {
     private static final String NEGOTIATION_AGREEMENT_TEMPLATE = "%s/negotiations/%s/agreement";
     private static final String NEGOTIATION_FINALIZE_TEMPLATE = "%s/negotiations/%s/events";
 
+    private ProviderActions() {
+    }
+
     public static void postOffer(ContractNegotiation negotiation) {
         var contractOffer = createOffer(
                 negotiation.getId(),
@@ -62,7 +65,8 @@ public class ProviderActions {
                 randomUUID().toString(),
                 negotiation.getCounterPartyId(),
                 TCK_PARTICIPANT_ID,
-                negotiation.getDatasetId());
+                negotiation.getDatasetId(),
+                negotiation.getCallbackAddress());
 
         negotiation.transition(AGREED);
         try (var response = postJson(format(NEGOTIATION_AGREEMENT_TEMPLATE, negotiation.getCallbackAddress(), negotiation.getCorrelationId()), agreement)) {
@@ -97,8 +101,5 @@ public class ProviderActions {
         if (!response.isSuccessful()) {
             throw new AssertionError("Unexpected response code: " + response.code());
         }
-    }
-
-    private ProviderActions() {
     }
 }

--- a/dsp/dsp-contract-negotiation/src/main/resources/common/context-schema.json
+++ b/dsp/dsp-contract-negotiation/src/main/resources/common/context-schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "ContextSchema",
+  "type": "array",
+  "items": {
+    "type": "string"
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/ContextSchema"
+    }
+  ],
+  "$id": "https://w3id.org/dspace/2025/1/common/context-schema.json",
+  "definitions": {
+    "ContextSchema": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "items": {
+          "type": "string"
+        }
+      },
+      "contains": {
+        "const": "https://w3id.org/dspace/2025/1/context.jsonld"
+      }
+    }
+  }
+}

--- a/dsp/dsp-contract-negotiation/src/main/resources/negotiation/contract-agreement-message-schema.json
+++ b/dsp/dsp-contract-negotiation/src/main/resources/negotiation/contract-agreement-message-schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "ContractAgreementMessageSchema",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/ContractAgreementMessage"
+    }
+  ],
+  "$id": "https://w3id.org/dspace/2025/1/negotiation/contract-agreement-message-schema.json",
+  "definitions": {
+    "ContractAgreementMessage": {
+      "type": "object",
+      "properties": {
+        "@context": {
+          "$ref": "https://w3id.org/dspace/2025/1/common/context-schema.json"
+        },
+        "@type": {
+          "type": "string",
+          "const": "ContractAgreementMessage"
+        },
+        "providerPid": {
+          "type": "string"
+        },
+        "consumerPid": {
+          "type": "string"
+        },
+        "agreement": {
+          "$ref": "https://w3id.org/dspace/2025/1/negotiation/contract-schema.json#/definitions/Agreement"
+        },
+        "callbackAddress": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "@context",
+        "@type",
+        "providerPid",
+        "consumerPid",
+        "agreement",
+        "callbackAddress"
+      ]
+    }
+  }
+}

--- a/dsp/dsp-contract-negotiation/src/main/resources/negotiation/contract-agreement-verification-message-schema.json
+++ b/dsp/dsp-contract-negotiation/src/main/resources/negotiation/contract-agreement-verification-message-schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "ContractAgreementVerificationMessageSchema",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/ContractAgreementVerificationMessage"
+    }
+  ],
+  "$id": "https://w3id.org/dspace/2025/1/negotiation/contract-agreement-verification-message-schema.json",
+  "definitions": {
+    "ContractAgreementVerificationMessage": {
+      "type": "object",
+      "properties": {
+        "@context": {
+          "$ref": "https://w3id.org/dspace/2025/1/common/context-schema.json"
+        },
+        "@type": {
+          "type": "string",
+          "const": "ContractAgreementVerificationMessage"
+        },
+        "providerPid": {
+          "type": "string"
+        },
+        "consumerPid": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "@context",
+        "@type",
+        "providerPid",
+        "consumerPid"
+      ]
+    }
+  }
+}

--- a/dsp/dsp-contract-negotiation/src/main/resources/negotiation/contract-negotiation-error-schema.json
+++ b/dsp/dsp-contract-negotiation/src/main/resources/negotiation/contract-negotiation-error-schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "ContractNegotiationErrorSchema",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/ContractNegotiationError"
+    }
+  ],
+  "$id": "https://w3id.org/dspace/2025/1/negotiation/contract-negotiation-error-schema.json",
+  "definitions": {
+    "ContractNegotiationError": {
+      "type": "object",
+      "properties": {
+        "@context": {
+          "$ref": "https://w3id.org/dspace/2025/1/common/context-schema.json"
+        },
+        "@type": {
+          "type": "string",
+          "const": "ContractNegotiationError"
+        },
+        "providerPid": {
+          "type": "string"
+        },
+        "consumerPid": {
+          "type": "string"
+        },
+        "code": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "array",
+          "minItems": 1,
+          "items": {}
+        }
+      },
+      "required": [
+        "@context",
+        "@type",
+        "providerPid",
+        "consumerPid"
+      ]
+    }
+  }
+}

--- a/dsp/dsp-contract-negotiation/src/main/resources/negotiation/contract-negotiation-event-message-schema.json
+++ b/dsp/dsp-contract-negotiation/src/main/resources/negotiation/contract-negotiation-event-message-schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "ContractNegotiationEventMessageSchema",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/ContractNegotiationEventMessage"
+    }
+  ],
+  "$id": "https://w3id.org/dspace/2025/1/negotiation/contract-negotiation-event-message-schema.json",
+  "definitions": {
+    "ContractNegotiationEventMessage": {
+      "type": "object",
+      "properties": {
+        "@context": {
+          "$ref": "https://w3id.org/dspace/2025/1/common/context-schema.json"
+        },
+        "@type": {
+          "type": "string",
+          "const": "ContractNegotiationEventMessage"
+        },
+        "providerPid": {
+          "type": "string"
+        },
+        "consumerPid": {
+          "type": "string"
+        },
+        "eventType": {
+          "type": "string",
+          "enum": [
+            "ACCEPTED",
+            "FINALIZED"
+          ]
+        }
+      },
+      "required": [
+        "@context",
+        "@type",
+        "providerPid",
+        "consumerPid",
+        "eventType"
+      ]
+    }
+  }
+}

--- a/dsp/dsp-contract-negotiation/src/main/resources/negotiation/contract-negotiation-schema.json
+++ b/dsp/dsp-contract-negotiation/src/main/resources/negotiation/contract-negotiation-schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "ContractNegotiationSchema",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/ContractNegotiation"
+    }
+  ],
+  "$id": "https://w3id.org/dspace/2025/1/negotiation/contract-negotiation-schema.json",
+  "definitions": {
+    "ContractNegotiation": {
+      "type": "object",
+      "properties": {
+        "@context": {
+          "$ref": "https://w3id.org/dspace/2025/1/common/context-schema.json"
+        },
+        "@type": {
+          "type": "string",
+          "const": "ContractNegotiation"
+        },
+        "providerPid": {
+          "type": "string"
+        },
+        "consumerPid": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "REQUESTED",
+            "OFFERED",
+            "ACCEPTED",
+            "AGREED",
+            "VERIFIED",
+            "FINALIZED",
+            "TERMINATED"
+          ]
+        }
+      },
+      "required": [
+        "@context",
+        "@type",
+        "providerPid",
+        "consumerPid",
+        "state"
+      ]
+    }
+  }
+}

--- a/dsp/dsp-contract-negotiation/src/main/resources/negotiation/contract-negotiation-termination-message-schema.json
+++ b/dsp/dsp-contract-negotiation/src/main/resources/negotiation/contract-negotiation-termination-message-schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "ContractNegotiationTerminationMessageSchema",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/ContractNegotiationTerminationMessage"
+    }
+  ],
+  "$id": "https://w3id.org/dspace/2025/1/negotiation/contract-negotiation-termination-message-schema.json",
+  "definitions": {
+    "ContractNegotiationTerminationMessage": {
+      "type": "object",
+      "properties": {
+        "@context": {
+          "$ref": "https://w3id.org/dspace/2025/1/common/context-schema.json"
+        },
+        "@type": {
+          "type": "string",
+          "const": "ContractNegotiationTerminationMessage"
+        },
+        "providerPid": {
+          "type": "string"
+        },
+        "consumerPid": {
+          "type": "string"
+        },
+        "code": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "array",
+          "minItems": 1,
+          "items": {}
+        }
+      },
+      "required": [
+        "@context",
+        "@type",
+        "providerPid",
+        "consumerPid"
+      ]
+    }
+  }
+}

--- a/dsp/dsp-contract-negotiation/src/main/resources/negotiation/contract-offer-message-schema.json
+++ b/dsp/dsp-contract-negotiation/src/main/resources/negotiation/contract-offer-message-schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "ContractOfferMessageSchema",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/ContractOfferMessage"
+    }
+  ],
+  "$id": "https://w3id.org/dspace/2025/1/negotiation/contract-offer-message-schema.json",
+  "definitions": {
+    "ContractOfferMessage": {
+      "type": "object",
+      "properties": {
+        "@context": {
+          "$ref": "https://w3id.org/dspace/2025/1/common/context-schema.json"
+        },
+        "@type": {
+          "type": "string",
+          "const": "ContractOfferMessage"
+        },
+        "providerPid": {
+          "type": "string"
+        },
+        "consumerPid": {
+          "type": "string"
+        },
+        "offer": {
+          "allOf": [
+            {
+              "$ref": "https://w3id.org/dspace/2025/1/negotiation/contract-schema.json#/definitions/MessageOffer"
+            },
+            {
+              "properties": {
+                "@id": {
+                  "type": "string"
+                },
+                "target": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "@id",
+                "target"
+              ]
+            }
+          ]
+        },
+        "callbackAddress": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "@context",
+        "@type",
+        "providerPid",
+        "offer",
+        "callbackAddress"
+      ]
+    }
+  }
+}

--- a/dsp/dsp-contract-negotiation/src/main/resources/negotiation/contract-request-message-schema.json
+++ b/dsp/dsp-contract-negotiation/src/main/resources/negotiation/contract-request-message-schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "ContractRequestMessageSchema",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/ContractRequestMessage"
+    }
+  ],
+  "$id": "https://w3id.org/dspace/2025/1/negotiation/contract-request-message-schema.json",
+  "definitions": {
+    "ContractRequestMessage": {
+      "type": "object",
+      "properties": {
+        "@context": {
+          "$ref": "https://w3id.org/dspace/2025/1/common/context-schema.json"
+        },
+        "@type": {
+          "type": "string",
+          "const": "ContractRequestMessage"
+        },
+        "consumerPid": {
+          "type": "string"
+        },
+        "providerPid": {
+          "type": "string"
+        },
+        "offer": {
+          "oneOf": [
+            {
+              "$ref": "https://w3id.org/dspace/2025/1/negotiation/contract-schema.json#/definitions/MessageOffer"
+            },
+            {
+              "properties": {
+                "@id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "@id"
+              ],
+              "not": {
+                "anyOf": [
+                  {
+                    "required": [
+                      "permission"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "prohibition"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "callbackAddress": {
+          "type": "string",
+          "$comment": "A URL indicating where messages to the consumer should be sent"
+        }
+      },
+      "required": [
+        "@context",
+        "@type",
+        "consumerPid",
+        "offer",
+        "callbackAddress"
+      ]
+    }
+  }
+}

--- a/dsp/dsp-contract-negotiation/src/main/resources/negotiation/contract-schema.json
+++ b/dsp/dsp-contract-negotiation/src/main/resources/negotiation/contract-schema.json
@@ -1,0 +1,327 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "PolicySchema",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/Policy"
+    }
+  ],
+  "$id": "https://w3id.org/dspace/2025/1/negotiation/contract-schema.json",
+  "definitions": {
+    "Policy": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/MessageOffer"
+        },
+        {
+          "$ref": "#/definitions/Offer"
+        },
+        {
+          "$ref": "#/definitions/Agreement"
+        }
+      ]
+    },
+    "PolicyClass": {
+      "type": "object",
+      "properties": {
+        "@id": {
+          "type": "string"
+        },
+        "profile": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": "string"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "permission": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Permission"
+          },
+          "minItems": 1
+        },
+        "obligation": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Duty"
+          },
+          "minItems": 1
+        }
+      },
+      "required": [
+        "@id"
+      ]
+    },
+    "MessageOffer": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/PolicyClass"
+        },
+        {
+          "properties": {
+            "@type": {
+              "type": "string",
+              "const": "Offer"
+            }
+          }
+        },
+        {
+          "anyOf": [
+            {
+              "required": [
+                "permission"
+              ]
+            },
+            {
+              "required": [
+                "prohibition"
+              ]
+            }
+          ]
+        }
+      ],
+      "required": [
+        "@type"
+      ]
+    },
+    "Offer": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/MessageOffer"
+        }
+      ],
+      "not": {
+        "required": [
+          "target"
+        ]
+      }
+    },
+    "Agreement": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/PolicyClass"
+        },
+        {
+          "properties": {
+            "@type": {
+              "type": "string",
+              "const": "Agreement"
+            },
+            "target": {
+              "type": "string"
+            },
+            "assigner": {
+              "type": "string"
+            },
+            "assignee": {
+              "type": "string"
+            },
+            "timestamp": {
+              "type": "string",
+              "pattern": "-?([1-9][0-9]{3,}|0[0-9]{3})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\.[0-9]+)?|(24:00:00(\\.0+)?))(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?"
+            }
+          }
+        },
+        {
+          "anyOf": [
+            {
+              "required": [
+                "permission"
+              ]
+            },
+            {
+              "required": [
+                "prohibition"
+              ]
+            }
+          ]
+        }
+      ],
+      "required": [
+        "@type",
+        "target",
+        "assignee",
+        "assigner"
+      ]
+    },
+    "Permission": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "$ref": "#/definitions/Action"
+        },
+        "constraint": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Constraint"
+          }
+        },
+        "duty": {
+          "$ref": "#/definitions/Duty"
+        }
+      },
+      "required": [
+        "action"
+      ]
+    },
+    "Duty": {
+      "type": "object",
+      "allOf": [
+        {
+          "properties": {
+            "action": {
+              "$ref": "#/definitions/Action"
+            },
+            "constraint": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Constraint"
+              }
+            }
+          },
+          "required": [
+            "action"
+          ]
+        }
+      ]
+    },
+    "Action": {
+      "type": "string"
+    },
+    "Constraint": {
+      "type": "object",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/LogicalConstraint"
+        },
+        {
+          "$ref": "#/definitions/AtomicConstraint"
+        }
+      ]
+    },
+    "LogicalConstraint": {
+      "type": "object",
+      "properties": {
+        "and": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Constraint"
+          }
+        },
+        "andSequence": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Constraint"
+          }
+        },
+        "or": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Constraint"
+          }
+        },
+        "xone": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Constraint"
+          }
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "and"
+          ]
+        },
+        {
+          "required": [
+            "andSequence"
+          ]
+        },
+        {
+          "required": [
+            "or"
+          ]
+        },
+        {
+          "required": [
+            "xone"
+          ]
+        }
+      ]
+    },
+    "AtomicConstraint": {
+      "type": "object",
+      "properties": {
+        "rightOperand": {
+          "$ref": "#/definitions/RightOperand"
+        },
+        "leftOperand": {
+          "$ref": "#/definitions/LeftOperand"
+        },
+        "operator": {
+          "$ref": "#/definitions/Operator"
+        }
+      },
+      "required": [
+        "rightOperand",
+        "operator",
+        "leftOperand"
+      ]
+    },
+    "Operator": {
+      "type": "string",
+      "enum": [
+        "eq",
+        "gt",
+        "gteq",
+        "lteq",
+        "hasPart",
+        "isA",
+        "isAllOf",
+        "isAnyOf",
+        "isNoneOf",
+        "isPartOf",
+        "lt",
+        "term-lteq",
+        "neq"
+      ]
+    },
+    "RightOperand": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object"
+        },
+        {
+          "type": "array"
+        }
+      ]
+    },
+    "LeftOperand": {
+      "type": "string"
+    },
+    "Reference": {
+      "type": "object",
+      "properties": {
+        "@id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "@id"
+      ]
+    }
+  }
+}

--- a/dsp/dsp-contract-negotiation/src/test/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationProvider02TestTest.java
+++ b/dsp/dsp-contract-negotiation/src/test/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationProvider02TestTest.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspacetck.dsp.verification.cn;
+
+public class ContractNegotiationProvider02TestTest extends ContractNegotiationProvider02Test {
+}

--- a/dsp/dsp-contract-negotiation/src/test/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationProvider03TestTest.java
+++ b/dsp/dsp-contract-negotiation/src/test/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationProvider03TestTest.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspacetck.dsp.verification.cn;
+
+public class ContractNegotiationProvider03TestTest extends ContractNegotiationProvider03Test {
+}

--- a/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/connector/ConsumerNegotiationManagerImpl.java
+++ b/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/connector/ConsumerNegotiationManagerImpl.java
@@ -35,7 +35,7 @@ import static org.eclipse.dataspacetck.dsp.system.api.statemachine.ContractNegot
  * Manages contract negotiations on a consumer.
  */
 public class ConsumerNegotiationManagerImpl extends AbstractNegotiationManager implements ConsumerNegotiationManager {
-    private Monitor monitor;
+    private final Monitor monitor;
 
     public ConsumerNegotiationManagerImpl(Monitor monitor) {
         this.monitor = monitor;
@@ -85,28 +85,28 @@ public class ConsumerNegotiationManagerImpl extends AbstractNegotiationManager i
 
     @Override
     public Map<String, Object> handleOffer(Map<String, Object> offer) {
-        var providerId = stringIdProperty(DSPACE_PROPERTY_PROVIDER_PID_EXPANDED, offer); // FIXME https://github.com/eclipse-dataspacetck/cvf/issues/92
+        var providerId = stringIdProperty(DSPACE_PROPERTY_PROVIDER_PID_EXPANDED, offer);
         monitor.debug("Received provider offer: " + providerId);
-        var consumerId = stringIdProperty(DSPACE_PROPERTY_CONSUMER_PID_EXPANDED, offer); // FIXME https://github.com/eclipse-dataspacetck/cvf/issues/92
+        var consumerId = stringIdProperty(DSPACE_PROPERTY_CONSUMER_PID_EXPANDED, offer);
         var negotiation = findById(consumerId);
         negotiation.storeOffer(offer, OFFERED, n -> listeners.forEach(l -> l.offered(negotiation)));
-        return createNegotiationResponse(negotiation.getCorrelationId(), negotiation.getId(), OFFERED.toString().toLowerCase());
+        return createNegotiationResponse(negotiation.getCorrelationId(), negotiation.getId(), OFFERED.toString());
     }
 
     @Override
     public void handleAgreement(Map<String, Object> agreement) {
-        var providerId = stringIdProperty(DSPACE_PROPERTY_PROVIDER_PID_EXPANDED, agreement); // FIXME https://github.com/eclipse-dataspacetck/cvf/issues/92
+        var providerId = stringIdProperty(DSPACE_PROPERTY_PROVIDER_PID_EXPANDED, agreement);
         monitor.debug("Received provider agreement: " + providerId);
-        var consumerId = stringIdProperty(DSPACE_PROPERTY_CONSUMER_PID_EXPANDED, agreement); // // FIXME https://github.com/eclipse-dataspacetck/cvf/issues/92
+        var consumerId = stringIdProperty(DSPACE_PROPERTY_CONSUMER_PID_EXPANDED, agreement);
         var negotiation = findById(consumerId);
         negotiation.storeAgreement(agreement, n -> listeners.forEach(l -> l.agreed(negotiation)));
     }
 
     @Override
     public void handleFinalized(Map<String, Object> event) {
-        var providerId = stringIdProperty(DSPACE_PROPERTY_PROVIDER_PID_EXPANDED, event); // FIXME https://github.com/eclipse-dataspacetck/cvf/issues/92
+        var providerId = stringIdProperty(DSPACE_PROPERTY_PROVIDER_PID_EXPANDED, event);
         monitor.debug("Received provider finalize: " + providerId);
-        var consumerId = stringIdProperty(DSPACE_PROPERTY_CONSUMER_PID_EXPANDED, event); // FIXME https://github.com/eclipse-dataspacetck/cvf/issues/92
+        var consumerId = stringIdProperty(DSPACE_PROPERTY_CONSUMER_PID_EXPANDED, event);
         var negotiation = findById(consumerId);
         negotiation.transition(ContractNegotiation.State.FINALIZED, n -> listeners.forEach(l -> l.finalized(negotiation)));
     }

--- a/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/connector/TckConnector.java
+++ b/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/connector/TckConnector.java
@@ -24,8 +24,13 @@ import org.eclipse.dataspacetck.dsp.system.api.connector.ProviderNegotiationMana
  * Implements a simple, in-memory connector that supports control-plane operations for testing.
  */
 public class TckConnector implements Connector {
-    private ProviderNegotiationManager providerNegotiationManager;
-    private ConsumerNegotiationManager consumerNegotiationManager;
+    private final ProviderNegotiationManager providerNegotiationManager;
+    private final ConsumerNegotiationManager consumerNegotiationManager;
+
+    public TckConnector(Monitor monitor) {
+        consumerNegotiationManager = new ConsumerNegotiationManagerImpl(monitor);
+        providerNegotiationManager = new ProviderNegotiationManagerImpl();
+    }
 
     public ProviderNegotiationManager getProviderNegotiationManager() {
         return providerNegotiationManager;
@@ -33,10 +38,5 @@ public class TckConnector implements Connector {
 
     public ConsumerNegotiationManager getConsumerNegotiationManager() {
         return consumerNegotiationManager;
-    }
-
-    public TckConnector(Monitor monitor) {
-        consumerNegotiationManager = new ConsumerNegotiationManagerImpl(monitor);
-        providerNegotiationManager = new ProviderNegotiationManagerImpl();
     }
 }

--- a/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/mock/ConsumerNegotiationMockImpl.java
+++ b/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/mock/ConsumerNegotiationMockImpl.java
@@ -32,8 +32,8 @@ import static org.eclipse.dataspacetck.dsp.system.api.statemachine.ContractNegot
  * Default mock consumer implementation.
  */
 public class ConsumerNegotiationMockImpl extends AbstractNegotiationMock implements ConsumerNegotiationMock, NegotiationListener {
-    private ConsumerNegotiationManager manager;
-    private String baseAddress;
+    private final ConsumerNegotiationManager manager;
+    private final String baseAddress;
 
     public ConsumerNegotiationMockImpl(ConsumerNegotiationManager manager, Executor executor, String baseAddress) {
         super(executor);

--- a/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/mock/ProviderNegotiationMockImpl.java
+++ b/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/mock/ProviderNegotiationMockImpl.java
@@ -30,7 +30,7 @@ import static org.eclipse.dataspacetck.dsp.system.api.statemachine.ContractNegot
  * Default mock provider implementation.
  */
 public class ProviderNegotiationMockImpl extends AbstractNegotiationMock implements ProviderNegotiationMock, NegotiationListener {
-    private ProviderNegotiationManager manager;
+    private final ProviderNegotiationManager manager;
 
     public ProviderNegotiationMockImpl(ProviderNegotiationManager manager, Executor executor) {
         super(executor);

--- a/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/pipeline/AbstractNegotiationPipeline.java
+++ b/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/pipeline/AbstractNegotiationPipeline.java
@@ -16,7 +16,6 @@ package org.eclipse.dataspacetck.dsp.system.pipeline;
 import org.eclipse.dataspacetck.core.api.pipeline.AbstractAsyncPipeline;
 import org.eclipse.dataspacetck.core.api.system.CallbackEndpoint;
 import org.eclipse.dataspacetck.core.spi.boot.Monitor;
-import org.eclipse.dataspacetck.dsp.system.api.message.MessageFunctions;
 import org.eclipse.dataspacetck.dsp.system.api.pipeline.NegotiationPipeline;
 import org.eclipse.dataspacetck.dsp.system.api.statemachine.ContractNegotiation;
 
@@ -27,7 +26,7 @@ public abstract class AbstractNegotiationPipeline<P extends NegotiationPipeline<
     protected ContractNegotiation providerNegotiation;
 
     public AbstractNegotiationPipeline(CallbackEndpoint endpoint, Monitor monitor, long waitTime) {
-        super(endpoint, monitor, waitTime, MessageFunctions::createDspContext);
+        super(endpoint, monitor, waitTime);
     }
 
     public P thenWaitForState(ContractNegotiation.State state) {

--- a/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/pipeline/ProviderNegotiationPipelineImpl.java
+++ b/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/pipeline/ProviderNegotiationPipelineImpl.java
@@ -37,7 +37,6 @@ import static org.eclipse.dataspacetck.dsp.system.api.message.DspConstants.TCK_P
 import static org.eclipse.dataspacetck.dsp.system.api.message.MessageFunctions.createAcceptedEvent;
 import static org.eclipse.dataspacetck.dsp.system.api.message.MessageFunctions.createContractRequest;
 import static org.eclipse.dataspacetck.dsp.system.api.message.MessageFunctions.createCounterOffer;
-import static org.eclipse.dataspacetck.dsp.system.api.message.MessageFunctions.createDspContext;
 import static org.eclipse.dataspacetck.dsp.system.api.message.MessageFunctions.createTermination;
 import static org.eclipse.dataspacetck.dsp.system.api.message.MessageFunctions.createVerification;
 import static org.eclipse.dataspacetck.dsp.system.api.message.MessageFunctions.stringIdProperty;
@@ -53,9 +52,9 @@ public class ProviderNegotiationPipelineImpl extends AbstractNegotiationPipeline
     private static final String NEGOTIATIONS_TERMINATION_PATH = "/negotiations/[^/]+/termination/";
     private static final String NEGOTIATION_EVENT_PATH = "/negotiations/[^/]+/events";
 
-    private Connector consumerConnector;
-    private String providerConnectorId;
-    private ProviderNegotiationClient negotiationClient;
+    private final Connector consumerConnector;
+    private final String providerConnectorId;
+    private final ProviderNegotiationClient negotiationClient;
 
     public ProviderNegotiationPipelineImpl(ProviderNegotiationClient negotiationClient,
                                            CallbackEndpoint endpoint,
@@ -79,7 +78,7 @@ public class ProviderNegotiationPipelineImpl extends AbstractNegotiationPipeline
 
             monitor.debug("Sending contract request");
             var response = negotiationClient.contractRequest(contractRequest, providerConnectorId, false);
-            var correlationId = stringIdProperty(DSPACE_PROPERTY_PROVIDER_PID_EXPANDED, response); // FIXME https://github.com/eclipse-dataspacetck/cvf/issues/92
+            var correlationId = stringIdProperty(DSPACE_PROPERTY_PROVIDER_PID_EXPANDED, response);
             consumerConnector.getConsumerNegotiationManager().contractRequested(providerNegotiation.getId(), correlationId);
         });
         return this;
@@ -165,7 +164,7 @@ public class ProviderNegotiationPipelineImpl extends AbstractNegotiationPipeline
         expectLatches.add(latch);
         stages.add(() ->
                 endpoint.registerHandler(NEGOTIATIONS_OFFER_PATH, offer -> {
-                    var negotiation = action.apply((processJsonLd(offer, createDspContext())));
+                    var negotiation = action.apply((processJsonLd(offer)));
                     endpoint.deregisterHandler(NEGOTIATIONS_OFFER_PATH);
                     latch.countDown();
                     return serialize(negotiation);

--- a/dsp/dsp-tck/notice.md
+++ b/dsp/dsp-tck/notice.md
@@ -4,14 +4,14 @@ A DSP TCK runtime that performs compatibility tests against a running connector 
 
 DockerHub: <https://hub.docker.com/r/eclipsedataspacetck/dsp-tck-runtime>
 
-Eclipse Tractus-X product(s) installed within the image:
+Eclipse Dataspace TCK product(s) installed within the image:
 
-## Tractus-X EDC Control Plane
+## Dataspace DSP TCK
 
 - GitHub: <https://github.com/eclipse-dataspacetck/dsp-tck>
 - Project home: <https://projects.eclipse.org/projects/technology.dataspacetck>
 - Dockerfile: <https://github.com/eclipse-dataspacetck/dsp-tck/blob/main/dsp/dsp-tck/src/main/docker/Dockerfile>
-- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/tractusx-edc/blob/main/LICENSE)
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-dataspacetck/dsp-tck/blob/main/LICENSE.md)
 
 ## Used base image
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ okhttp = "4.12.0"
 mockito = "5.13.0"
 tck = "0.1.0"
 titanium = "1.4.1"
+schema-validator = "1.5.2"
 
 [libraries]
 
@@ -29,7 +30,7 @@ junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 titanium = { module = "com.apicatalog:titanium-json-ld", version.ref = "titanium" }
-
+schema-validator = { module = "com.networknt:json-schema-validator", version.ref = "schema-validator" }
 
 [plugins]
 docker = { id = "com.bmuschko.docker-remote-api", version = "9.4.0" }


### PR DESCRIPTION
## What this PR changes/adds

This PR:

- Switches the protocol version to 2025-1
- Removes the prefixed properties and use plain one when creating messages (since there is a JSON-LD context definition) 
- Preserves expansion and compaction on ingress and egress
- Still uses expanded properties when reading messages content
- Adds messages validation on ingress and egress according to the `@type` of the message
- Allows connector under tests to configure custom JSON-LD context

## Why it does that

_Briefly state why the change was necessary._

## Further notes

`MessageSerializer` should  be improved, currently the configuration is static and exposes static  methods for:

- registering validators
- loading custom contexts
- serializing and de-serializing objects

Refactoring it to be a injectable is probably better in the long run 

## Linked Issue(s)

Closes #143 

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
