### PR TITLE
chore: switch the log version to 2025.1

### DIFF
--- a/dsp/dsp-tck/src/main/java/org/eclipse/dataspacetck/dsp/suite/DspTckSuite.java
+++ b/dsp/dsp-tck/src/main/java/org/eclipse/dataspacetck/dsp/suite/DspTckSuite.java
@@ -37,7 +37,7 @@ import static org.eclipse.dataspacetck.core.system.ConsoleMonitor.DEBUG_PROPERTY
  * Launches the DSP TCK and runs the test suite.
  */
 public class DspTckSuite {
-    private static final String VERSION = "2024.1";
+    private static final String VERSION = "2025.1";
     private static final String CONFIG = "-config";
     private static final String DEFAULT_LAUNCHER = "org.eclipse.dataspacetck.dsp.system.DspSystemLauncher";
     private static final String TEST_PACKAGE = "org.eclipse.dataspacetck.dsp.verification";


### PR DESCRIPTION
## What this PR changes/adds

switch the log version to 2025.1

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
