### PR TITLE
fix: reset `started` flag on close

### DIFF
--- a/core/src/main/java/org/eclipse/dataspacetck/core/system/SystemBootstrapExtension.java
+++ b/core/src/main/java/org/eclipse/dataspacetck/core/system/SystemBootstrapExtension.java
@@ -132,6 +132,7 @@ public class SystemBootstrapExtension implements BeforeAllCallback,
         if (executorService != null) {
             executorService.shutdown();
         }
+        started = false;
     }
 
     @Override
@@ -224,7 +225,7 @@ public class SystemBootstrapExtension implements BeforeAllCallback,
     }
 
     private static class DispatchingHandler implements HttpHandler {
-        private Queue<DefaultCallbackEndpoint> endpoints = new ConcurrentLinkedQueue<>();
+        private final Queue<DefaultCallbackEndpoint> endpoints = new ConcurrentLinkedQueue<>();
 
         void registerEndpoint(DefaultCallbackEndpoint endpoint) {
             endpoints.add(endpoint);


### PR DESCRIPTION

## What this PR changes/adds

reset the `started` flag when the test class completes (on `close`)

## Why it does that

running subsequent test classes will cause the second one not be initialized properly, because the `started` flag is still `true`, and thus the old config is retained.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
