### PR TITLE
fix: use different path when sending consumer counter offer

### DIFF
--- a/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationProvider03Test.java
+++ b/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationProvider03Test.java
@@ -160,8 +160,8 @@ public class ContractNegotiationProvider03Test extends AbstractContractNegotiati
                 .expectOfferMessage(offer -> consumerConnector.getConsumerNegotiationManager().handleOffer(offer))
                 .sendRequestMessage(datasetId, offerId)
                 .thenWaitForState(OFFERED)
-                .sendCounterOfferMessage("CD123:ACN0304:456", "ACN0304")
-                .sendCounterOfferMessage("CD123:ACN0304:456", "ACN0304", true) // send second offer
+                .sendCounterOfferMessage(offerId, datasetId)
+                .sendCounterOfferMessage(offerId, datasetId, true) // send second offer
                 .execute();
 
         negotiationMock.verify();

--- a/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/client/cn/ProviderNegotiationClient.java
+++ b/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/client/cn/ProviderNegotiationClient.java
@@ -22,9 +22,14 @@ import java.util.Map;
 public interface ProviderNegotiationClient extends NegotiationClient {
 
     /**
-     * Sends the contract request to the provider. Used for initial requests and client counter-offers.
+     * Sends the contract request to the provider. Used for initial requests.
      */
     Map<String, Object> contractRequest(Map<String, Object> message, String counterPartyId, boolean expectError);
+
+    /**
+     * Sends a subsequent contract request to the provider. Used client counter-offers.
+     */
+    void contractOfferRequest(Map<String, Object> message, String counterPartyId, boolean expectError);
 
     /**
      * Sends the accepted event to the provider connector.

--- a/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/client/cn/http/HttpProviderNegotiationClientImpl.java
+++ b/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/client/cn/http/HttpProviderNegotiationClientImpl.java
@@ -37,9 +37,10 @@ import static org.eclipse.dataspacetck.dsp.system.api.message.JsonLdFunctions.st
 public class HttpProviderNegotiationClientImpl extends AbstractHttpNegotiationClient implements ProviderNegotiationClient {
     private static final String GET_PATH = "negotiations/%s";
     private static final String REQUEST_PATH = "negotiations/request";
-    private static final String TERMINATE_PATH = "negotiations/%s/termination";
     private static final String EVENT_PATH = "negotiations/%s/events";
     private static final String VERIFICATION_PATH = "negotiations/%s/agreement/verification";
+    private static final String REQUEST_OFFER_PATH = "negotiations/%s/request";
+
     private final Monitor monitor;
     private final String providerConnectorBaseUrl;
     private Connector systemConnector;
@@ -56,6 +57,14 @@ public class HttpProviderNegotiationClientImpl extends AbstractHttpNegotiationCl
             monitor.debug("Received contract request response");
             //noinspection DataFlowIssue
             return processJsonLd(response.body().byteStream());
+        }
+    }
+
+    @Override
+    public void contractOfferRequest(Map<String, Object> contractRequest, String counterPartyId, boolean expectError) {
+        var providerId = compactStringProperty(DSPACE_PROPERTY_PROVIDER_PID, contractRequest);
+        try (var response = postJson(providerConnectorBaseUrl + format(REQUEST_OFFER_PATH, providerId), contractRequest, expectError)) {
+            monitor.debug("Received contract offer request response");
         }
     }
 

--- a/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/client/cn/local/LocalProviderNegotiationClientImpl.java
+++ b/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/client/cn/local/LocalProviderNegotiationClientImpl.java
@@ -41,6 +41,11 @@ public class LocalProviderNegotiationClientImpl extends AbstractLocalNegotiation
     }
 
     @Override
+    public void contractOfferRequest(Map<String, Object> message, String counterPartyId, boolean expectError) {
+        contractRequest(message, counterPartyId, expectError);
+    }
+
+    @Override
     public void accept(Map<String, Object> event) {
         var compacted = processJsonLd(event);
         systemConnector.getProviderNegotiationManager().handleAccepted(compacted);

--- a/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/pipeline/ProviderNegotiationPipelineImpl.java
+++ b/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/pipeline/ProviderNegotiationPipelineImpl.java
@@ -107,7 +107,7 @@ public class ProviderNegotiationPipelineImpl extends AbstractNegotiationPipeline
             if (!expectError) {
                 consumerConnector.getConsumerNegotiationManager().counterOffered(consumerId);
             }
-            negotiationClient.contractRequest(contractRequest, providerConnectorId, expectError);
+            negotiationClient.contractOfferRequest(contractRequest, providerConnectorId, expectError);
         });
         return this;
     }
@@ -191,7 +191,7 @@ public class ProviderNegotiationPipelineImpl extends AbstractNegotiationPipeline
         });
         return this;
     }
-    
+
     @Override
     protected ProviderNegotiationPipeline self() {
         return this;


### PR DESCRIPTION
## What this PR changes/adds

Uses the right contract request path when sending the counter offer from the consumer 

## Why it does that

dsp compliance

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #161 

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
