### PR TITLE
chore: fix finalize call on http when error is expected

### DIFF
--- a/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationConsumer03Test.java
+++ b/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationConsumer03Test.java
@@ -142,12 +142,6 @@ public class ContractNegotiationConsumer03Test extends AbstractContractNegotiati
             CUT->>TCK: ContractNegotiationEventMessage:accepted
             TCK-->>CUT: 200 OK
             
-            TCK->>CUT: ContractAgreementMessage
-            CUT-->>TCK: 200 OK
-            
-            CUT->>TCK: ContractAgreementVerificationMessage
-            TCK-->>CUT: 200 OK
-            
             TCK->>CUT: ContractNegotiationEventMessage:finalized
             CUT-->>TCK: 4xx ERROR
             """)

--- a/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/client/cn/http/HttpConsumerNegotiationClientImpl.java
+++ b/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/client/cn/http/HttpConsumerNegotiationClientImpl.java
@@ -80,7 +80,7 @@ public class HttpConsumerNegotiationClientImpl extends AbstractHttpNegotiationCl
 
     @Override
     public void finalize(String consumerId, Map<String, Object> event, String callbackAddress, boolean expectError) {
-        try (var response = postJson(format(FINALIZE_PATH, callbackAddress, consumerId), event, false)) {
+        try (var response = postJson(format(FINALIZE_PATH, callbackAddress, consumerId), event, expectError)) {
             monitor.debug("Received contract finalize response");
             // TODO Validate response
             // processJsonLd(response.body().byteStream(), createDspContext());


### PR DESCRIPTION
## What this PR changes/adds

fixes finalize call on http when error is expected.

Also fixes diagram description for `CN_C:03-04`

## Why it does that

bug fix

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
