### PR TITLE
fix: fixes diagram for CN_C:03-06 expecting error

### DIFF
--- a/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationConsumer03Test.java
+++ b/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationConsumer03Test.java
@@ -222,7 +222,7 @@ public class ContractNegotiationConsumer03Test extends AbstractContractNegotiati
             CUT-->>TCK: 200 OK
             
             TCK->>CUT: ContractNegotiationEventMessage:finalized
-            CUT-->>TCK: 200 OK
+            CUT-->>TCK: 4xx ERROR
             """)
     public void cn_c_03_06() {
         negotiationMock.recordInitializedAction(ConsumerActions::postRequest);

--- a/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationProvider03Test.java
+++ b/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationProvider03Test.java
@@ -62,6 +62,7 @@ public class ContractNegotiationProvider03Test extends AbstractContractNegotiati
                 .expectFinalizedEvent(event -> consumerConnector.getConsumerNegotiationManager().handleFinalized(event))
                 .sendVerifiedEvent()
                 .thenWaitForState(FINALIZED)
+                .thenVerifyProviderState(FINALIZED)
                 .sendTermination(true)
                 .execute();
 


### PR DESCRIPTION
## What this PR changes/adds

fixes diagram for CN_C:03-06 expecting error

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
