### PR TITLE
feat: DefaultCallbackEndpoint implements Autocloseable

### DIFF
--- a/core/src/main/java/org/eclipse/dataspacetck/core/system/DefaultCallbackEndpoint.java
+++ b/core/src/main/java/org/eclipse/dataspacetck/core/system/DefaultCallbackEndpoint.java
@@ -39,7 +39,7 @@ import static java.util.regex.Pattern.compile;
  * <p>
  * Deserialized messages from incoming transports such as HTTP are dispatched to a registered handler through this endpoint by calling {@link #apply(String, InputStream)}.
  */
-public class DefaultCallbackEndpoint implements CallbackEndpoint, BiFunction<String, InputStream, String>, ExtensionContext.Store.CloseableResource {
+public class DefaultCallbackEndpoint implements CallbackEndpoint, BiFunction<String, InputStream, String>, AutoCloseable {
 
     private final List<LifecycleListener> listeners = new ArrayList<>();
     private final Map<String, ProtocolHandler> handlers = new HashMap<>();

--- a/core/src/main/java/org/eclipse/dataspacetck/core/system/DefaultCallbackEndpoint.java
+++ b/core/src/main/java/org/eclipse/dataspacetck/core/system/DefaultCallbackEndpoint.java
@@ -19,7 +19,6 @@ import org.eclipse.dataspacetck.core.api.system.CallbackEndpoint;
 import org.eclipse.dataspacetck.core.api.system.HandlerResponse;
 import org.eclipse.dataspacetck.core.api.system.ProtocolHandler;
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -104,10 +103,10 @@ public class DefaultCallbackEndpoint implements CallbackEndpoint, BiFunction<Str
      */
     private Optional<ProtocolHandler> lookupHandler(String expression) {
         return handlers.entrySet()
-                .stream()
-                .filter(entry -> compile(entry.getKey()).matcher(expression).matches())
-                .map(Map.Entry::getValue)
-                .findFirst();
+                       .stream()
+                       .filter(entry -> compile(entry.getKey()).matcher(expression).matches())
+                       .map(Map.Entry::getValue)
+                       .findFirst();
     }
 
     @FunctionalInterface

--- a/core/src/main/java/org/eclipse/dataspacetck/core/system/SystemBootstrapExtension.java
+++ b/core/src/main/java/org/eclipse/dataspacetck/core/system/SystemBootstrapExtension.java
@@ -55,7 +55,7 @@ public class SystemBootstrapExtension implements BeforeAllCallback,
         BeforeEachCallback,
         BeforeTestExecutionCallback,
         ParameterResolver,
-        ExtensionContext.Store.CloseableResource {
+        AutoCloseable {
 
     private static final ExtensionContext.Namespace CALLBACK_NAMESPACE = org.junit.jupiter.api.extension.ExtensionContext.Namespace.create(new Object());
 


### PR DESCRIPTION
## What this PR changes/adds

`DefaultCallbackEndpoint` implements `AutoCloseable` instead of the now-deprecated `ExtensionContext.Store.CloseableResource`

## Why it does that

deprecation notice

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
