### PR TITLE
feat: removes mandatory endpoint on data address

### DIFF
--- a/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/connector/tp/AbstractTransferProcessManager.java
+++ b/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/connector/tp/AbstractTransferProcessManager.java
@@ -168,7 +168,11 @@ public abstract class AbstractTransferProcessManager implements TransferProcessM
         }
 
         var endpointType = stringIdProperty(DSPACE_PROPERTY_ENDPOINT_TYPE_EXPANDED, dataAddress);
-        var endpoint = stringProperty(DSPACE_PROPERTY_ENDPOINT_EXPANDED, dataAddress);
+
+        String endpoint = null;
+        if (dataAddress.get(DSPACE_PROPERTY_ENDPOINT_EXPANDED) != null) {
+            endpoint = stringProperty(DSPACE_PROPERTY_ENDPOINT_EXPANDED, dataAddress);
+        }
         var endpointProperties = toEndpointProperties(dataAddress.get(DSPACE_PROPERTY_ENDPOINT_PROPERTIES_EXPANDED));
         return new TransferProcess.DataAddress(endpointType, endpoint, endpointProperties);
     }

--- a/dsp/dsp-transfer-process/src/main/java/org/eclipse/dataspacetck/dsp/verification/tp/TransferProcessConsumer02Test.java
+++ b/dsp/dsp-transfer-process/src/main/java/org/eclipse/dataspacetck/dsp/verification/tp/TransferProcessConsumer02Test.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspacetck.dsp.verification.tp;
 
 import org.eclipse.dataspacetck.api.system.MandatoryTest;
 import org.eclipse.dataspacetck.api.system.TestSequenceDiagram;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 
@@ -148,6 +149,7 @@ public class TransferProcessConsumer02Test extends AbstractTransferProcessConsum
         transferProcessMock.verify();
     }
 
+    @Disabled
     @MandatoryTest
     @DisplayName("TP_C:02-04: Verify transfer request, provider started, consumer suspended, consumer started, consumer completed")
     @TestSequenceDiagram("""

--- a/dsp/dsp-transfer-process/src/main/java/org/eclipse/dataspacetck/dsp/verification/tp/TransferProcessProvider02Test.java
+++ b/dsp/dsp-transfer-process/src/main/java/org/eclipse/dataspacetck/dsp/verification/tp/TransferProcessProvider02Test.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspacetck.dsp.verification.tp;
 
 import org.eclipse.dataspacetck.api.system.MandatoryTest;
 import org.eclipse.dataspacetck.api.system.TestSequenceDiagram;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 
@@ -131,6 +132,7 @@ public class TransferProcessProvider02Test extends AbstractTransferProcessProvid
         transferProcessMock.verify();
     }
 
+    @Disabled
     @MandatoryTest
     @DisplayName("TP:02-04: Verify transfer request, provider started, consumer suspended, consumer started, consumer completed")
     @TestSequenceDiagram("""

--- a/dsp/dsp-transfer-process/src/main/resources/transfer/data-address-schema.json
+++ b/dsp/dsp-transfer-process/src/main/resources/transfer/data-address-schema.json
@@ -32,8 +32,7 @@
       },
       "required": [
         "@type",
-        "endpointType",
-        "endpoint"
+        "endpointType"
       ]
     },
     "EndpointProperty": {


### PR DESCRIPTION
## What this PR changes/adds

This PR removes the endpoint as mandatory property [Ref](https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocol/issues/156).

Additionally add a retry with naive back-off when sending request from the tck if the status is 40X.

Also disable two test cases for now which may cause issue for implementors [Ref](https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocol/issues/167)

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
