### PR TITLE
fix: add TCK server config host + port

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ The following configuration is required to run the Dataspace Protocol TCK agains
 |---------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
 | `dataspacetck.debug`                                    | Enables debug logging for the TCK.                                                                                                         | `true`                               |
 | `dataspacetck.local.connector`                          | Enable the embedded connector, useful for testing and debugging the DSP TCK. It should be disabled when running against a remote connector | `false`                              |
+| `dataspacetck.host`                                     | The hostname of the TCK server.                                                                                                            | `0.0.0.0`                            |
+| `dataspacetck.port`                                     | The port of the TCK server.                                                                                                                | `8083`                               |
+| `dataspacetck.callback.address`                         | The callback address of the TCK. Attached as `callbackAddress` in DSP messages when required to signal the response channel to the CUT     | `http://localhost:8083`              |
 | `dataspacetck.dsp.connector.agent.id`                   | The agent ID of the connector under test. This is used to identify the connector in the TCK tests.                                         | `urn:connector:example-connector`    |
 | `dataspacetck.dsp.connector.http.url`                   | The dataspace protocol URL of the connector under test. This is used to access the connector's endpoints during the TCK tests.             | `http://localhost:8080/dsp`          |
 | `dataspacetck.dsp.connector.http.base.url`              | The base URL of the connector under test. This is used to access the connector's metadata endpoint during the TCK tests.                   | `http://localhost:8080`              |
@@ -337,4 +340,5 @@ By executing the following command, a test plan will be generated in the `build/
 
 ## 4. Filing Challenges
 
-If you believe there is a bug in the TCK or there is an invalid test assertion, please file a bug [here](https://github.com/eclipse-dataspacetck/dsp-tck/issues).
+If you believe there is a bug in the TCK or there is an invalid test assertion, please file a
+bug [here](https://github.com/eclipse-dataspacetck/dsp-tck/issues).

--- a/core/src/main/java/org/eclipse/dataspacetck/core/api/system/SystemsConstants.java
+++ b/core/src/main/java/org/eclipse/dataspacetck/core/api/system/SystemsConstants.java
@@ -20,6 +20,10 @@ package org.eclipse.dataspacetck.core.api.system;
 public interface SystemsConstants {
     String TCK_PREFIX = "dataspacetck";
     String TCK_CALLBACK_ADDRESS = TCK_PREFIX + ".callback.address";
+    String TCK_HOST = TCK_PREFIX + ".host";
+    String TCK_PORT = TCK_PREFIX + ".port";
     String TCK_DEFAULT_CALLBACK_ADDRESS = "http://localhost:8083";
+    String TCK_DEFAULT_HOST = "0.0.0.0";
+    int TCK_DEFAULT_PORT = 8083;
     String TCK_LAUNCHER = TCK_PREFIX + ".launcher";
 }

--- a/core/src/main/java/org/eclipse/dataspacetck/core/system/SystemBootstrapExtension.java
+++ b/core/src/main/java/org/eclipse/dataspacetck/core/system/SystemBootstrapExtension.java
@@ -36,7 +36,6 @@ import org.junit.platform.commons.JUnitException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.InetSocketAddress;
-import java.net.URI;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
@@ -45,7 +44,11 @@ import java.util.concurrent.Executors;
 import static java.lang.Boolean.parseBoolean;
 import static org.eclipse.dataspacetck.core.api.system.SystemsConstants.TCK_CALLBACK_ADDRESS;
 import static org.eclipse.dataspacetck.core.api.system.SystemsConstants.TCK_DEFAULT_CALLBACK_ADDRESS;
+import static org.eclipse.dataspacetck.core.api.system.SystemsConstants.TCK_DEFAULT_HOST;
+import static org.eclipse.dataspacetck.core.api.system.SystemsConstants.TCK_DEFAULT_PORT;
+import static org.eclipse.dataspacetck.core.api.system.SystemsConstants.TCK_HOST;
 import static org.eclipse.dataspacetck.core.api.system.SystemsConstants.TCK_LAUNCHER;
+import static org.eclipse.dataspacetck.core.api.system.SystemsConstants.TCK_PORT;
 import static org.eclipse.dataspacetck.core.system.ConfigFunctions.propertyOrEnv;
 import static org.eclipse.dataspacetck.core.system.ConsoleMonitor.ANSI_PROPERTY;
 import static org.eclipse.dataspacetck.core.system.ConsoleMonitor.DEBUG_PROPERTY;
@@ -80,10 +83,9 @@ public class SystemBootstrapExtension implements BeforeAllCallback,
 
         var ansi = parseBoolean(context.getConfigurationParameter(ANSI_PROPERTY).orElse(propertyOrEnv(ANSI_PROPERTY, "true")));
         var debug = parseBoolean(context.getConfigurationParameter(DEBUG_PROPERTY).orElse(propertyOrEnv(DEBUG_PROPERTY, "false")));
-        var callbackAddress = URI.create(context.getConfigurationParameter(TCK_CALLBACK_ADDRESS).orElse(propertyOrEnv(TCK_CALLBACK_ADDRESS, TCK_DEFAULT_CALLBACK_ADDRESS)));
 
-        this.callbackHost = callbackAddress.getHost();
-        this.callbackPort = callbackAddress.getPort();
+        this.callbackHost = context.getConfigurationParameter(TCK_HOST).orElse(TCK_DEFAULT_HOST);
+        this.callbackPort = context.getConfigurationParameter(TCK_PORT).map(Integer::parseInt).orElse(TCK_DEFAULT_PORT);
 
         monitor = new ConsoleMonitor(debug, ansi);
         var configuration = SystemConfiguration.Builder.newInstance()


### PR DESCRIPTION
## What this PR changes/adds

add TCK server config host + port

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #194 

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
