### PR TITLE
fix: check for binding in Metadata01Test

### DIFF
--- a/dsp/dsp-metadata/src/main/java/org/eclipse/dataspacetck/dsp/verification/metadata/Metadata01Test.java
+++ b/dsp/dsp-metadata/src/main/java/org/eclipse/dataspacetck/dsp/verification/metadata/Metadata01Test.java
@@ -56,6 +56,7 @@ public class Metadata01Test extends AbstractVerificationTest {
             assertThat(entry.get("version")).isNotNull()
                     .isEqualTo("2025-1");
             assertThat(entry.get("path")).isNotNull();
+            assertThat(entry.get("binding")).isNull();
         });
 
     }


### PR DESCRIPTION
## What this PR changes/adds

Adds an assertion to check if the attribute "binding" is part of Version object.

## Why it does that

Compliance with DSP 2025-1.

## Linked Issue(s)

Closes #197
