### PR TITLE
chore: bump jsonschema to 2.0.0

### DIFF
--- a/core/src/main/java/org/eclipse/dataspacetck/core/api/verification/AbstractVerificationTest.java
+++ b/core/src/main/java/org/eclipse/dataspacetck/core/api/verification/AbstractVerificationTest.java
@@ -15,17 +15,16 @@
 
 package org.eclipse.dataspacetck.core.api.verification;
 
-import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.Error;
 import com.networknt.schema.SchemaLocation;
-import com.networknt.schema.ValidationMessage;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.dialect.Dialects;
 import org.eclipse.dataspacetck.core.api.message.MessageValidator;
 import org.eclipse.dataspacetck.core.system.SystemBootstrapExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static com.networknt.schema.SpecVersion.VersionFlag.V202012;
 
 
 /**
@@ -37,9 +36,9 @@ public abstract class AbstractVerificationTest {
     protected static final String CLASSPATH_SCHEMA = "classpath:/";
     protected static final String DSPACE_NAMESPACE = "https://w3id.org/dspace/2025/1";
 
-    private static final JsonSchemaFactory SCHEMA_FACTORY = JsonSchemaFactory.getInstance(V202012, builder ->
-            builder.schemaMappers(schemaMappers ->
-                    schemaMappers.mapPrefix(DSPACE_NAMESPACE + "/", CLASSPATH_SCHEMA))
+    private static final SchemaRegistry SCHEMA_FACTORY = SchemaRegistry.withDialect(Dialects.getDraft201909(), builder ->
+            builder.schemaIdResolvers(schemaIdResolvers ->
+                    schemaIdResolvers.mapPrefix(DSPACE_NAMESPACE + "/", CLASSPATH_SCHEMA))
     );
 
 
@@ -51,7 +50,7 @@ public abstract class AbstractVerificationTest {
             if (response.isEmpty()) {
                 return List.of();
             }
-            return response.stream().map(ValidationMessage::getMessage).collect(Collectors.toList());
+            return response.stream().map(Error::getMessage).collect(Collectors.toList());
         };
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ okhttp = "5.3.0"
 mockito = "5.20.0"
 tck = "1.0.0-SNAPSHOT"
 titanium = "1.7.0"
-schema-validator = "1.5.9"
+schema-validator = "2.0.0"
 
 [libraries]
 


### PR DESCRIPTION
## What this PR changes/adds

bump jsonschema to 2.0.0 and fixes the breaking change

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
