### PR TITLE
build: expose all the required deps in dsp-tck

### DIFF
--- a/dsp/dsp-tck/build.gradle.kts
+++ b/dsp/dsp-tck/build.gradle.kts
@@ -29,14 +29,15 @@ plugins {
 }
 
 dependencies {
-    implementation(libs.tck.core)
-    implementation(project(":dsp:dsp-api"))
-    implementation(project(":dsp:dsp-system"))
-    implementation(project(":dsp:dsp-contract-negotiation"))
-    implementation(project(":dsp:dsp-transfer-process"))
-    implementation(project(":dsp:dsp-catalog"))
-    implementation(project(":dsp:dsp-metadata"))
-    implementation(libs.tck.runtime)
+    api(libs.tck.core)
+    api(project(":dsp:dsp-api"))
+    api(project(":dsp:dsp-system"))
+    api(project(":dsp:dsp-contract-negotiation"))
+    api(project(":dsp:dsp-transfer-process"))
+    api(project(":dsp:dsp-catalog"))
+    api(project(":dsp:dsp-metadata"))
+    api(libs.tck.runtime)
+
     implementation(libs.junit.platform.launcher)
     testImplementation(project(":dsp:dsp-contract-negotiation"))
     testImplementation(project(":dsp:dsp-transfer-process"))


### PR DESCRIPTION
## What this PR changes/adds

set tck related dependencies as api, so `dsp-`tck will become the only dependency that needs to be declared in order to being able to run the TCK harness

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #254 

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
